### PR TITLE
Fix every minute reconsoliation in case of succesfull import

### DIFF
--- a/cmd/main.go
+++ b/cmd/main.go
@@ -139,7 +139,7 @@ func (r *SecretSyncer) Reconcile(ctx context.Context, req ctrl.Request) (result 
 		// Handle other backends
 	}
 
-	return ctrl.Result{RequeueAfter: time.Minute}, nil
+	return ctrl.Result{}, nil
 }
 
 func (r *SecretSyncer) ingressesGetByLabels(ctx context.Context, labelSet map[string]string) (*networkingv1.IngressList, error) {


### PR DESCRIPTION
Currently controller sync all certificates every minute regardless of updates. This PR removes force-sync every minutes if there were no errors. There are still improvements to be made here, but this helps to ease the pressure on AWS PI in big-ish clusters. 